### PR TITLE
MODO-26 chore: 디자인 시스템 - 서치바 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,7 +29,7 @@ function App() {
       <div className="my-1 flex gap-2 flex-wrap justify-center">
         <span className="text-[16px] font-bold">서치바</span>
       </div>
-      <div className="my-4 flex gap-2 flex-wrap w-96 justify-center">
+      <div className="my-4 flex gap-2 flex-wrap w-full justify-center">
         <SearchBar />
       </div>
     </>

--- a/src/Components/SearchBar/index.tsx
+++ b/src/Components/SearchBar/index.tsx
@@ -7,16 +7,35 @@ export default function SearchBar() {
   };
   return (
     <>
-      <div>
-        <input
-          className="w-max py-2 display:flex rounded-xl border-0 bg-[#2925250D] text-md focus:ring-blue-500 focus:border-blue-500 "
-          type="text"
-          value={search}
-          onChange={onChange}
-          placeholder="찾으시는 도서명, 상점명을 검색해주세요"
-          required
-        />
-      </div>
+      <form className="w-full">
+        <div className="relative">
+          <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none ">
+            <svg
+              aria-hidden="true"
+              className="w-5 h-5 text-gray-500 dark:text-gray-400"
+              fill="none"
+              stroke="gray"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+              ></path>
+            </svg>
+          </div>
+          <input
+            className="w-full py-2 pl-10  text-start content-center rounded-xl border-0 bg-[#2925250D] text-md focus:ring-blue-500 focus:border-blue-500 "
+            type="text"
+            value={search}
+            onChange={onChange}
+            placeholder="찾으시는 도서명, 상점명을 검색해주세요"
+            required
+          />
+        </div>
+      </form>
     </>
   );
 }


### PR DESCRIPTION
[MODO-26]

### 🔨 지라 이슈

- [MODO-26]

### 📝 설명

- 피그마에 설계된 버튼과, 검색창을 컴포넌트로 구현하였습니다.
- 재사용이 가능하도록 설계하는데 집중했습니다.
- 페이지 디자인이 아직 완성되지 않은 상태라서, 임시로 1024px 정도를  max-width라고 고려하고 작업했습니다.
- @Coreight98  멘토님 조언대로 우선 순위에 따라 가장 많이 쓰일 디자인 시스템부터 그릴 수 있도록 작업하였습니다.
   디자인 파트(@siyeooon ) 에게 가장 많이 쓰일 것 같은 디자인 시스템부터  제작 부탁하여 구현 중입니다.
- 추가적으로 Vercel을 통해 배포하였습니다. (https://modo-fe.vercel.app/)

### 📷 사진
- 피그마 디자인 시스템
<img width="692" alt="스크린샷 2023-03-23 오후 6 32 00" src="https://user-images.githubusercontent.com/103026404/227161243-66fd1792-a6d0-4a58-a636-09a66bad2e0a.png">

- 구현
<img width="1440" alt="스크린샷 2023-03-23 오후 3 38 48" src="https://user-images.githubusercontent.com/103026404/227123690-ff91fe12-91f7-4111-846f-13e1fbb5a491.png">



[MODO-26]: https://ajoumodo.atlassian.net/browse/MODO-26?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MODO-26]: https://ajoumodo.atlassian.net/browse/MODO-26?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ