### PR TITLE
MODO-41-[HOTFIX]/mainPage: Vercel 빌드 에러

### DIFF
--- a/src/pages/mainpage/index.tsx
+++ b/src/pages/mainpage/index.tsx
@@ -11,21 +11,21 @@ export const MainPage = () => (
     <div className="flex-col my-5">
       <div className="flex">
         <div className="w-4/5">
-          <ItemTitle itemMainTitle="수원시" itemSubTitle="의 매물" />
+          <ItemTitle itemMainTitle="수원시" itemSubTitle="의 매물" itemToggle={true} />
           <ItemList itemName="원씽 The One Thing" itemPrice="500" itemState="대여가능" />
         </div>
         <div className="w-1/5">
-          <ItemTitle itemMainTitle="" itemSubTitle="사용자 랭킹" />
+          <ItemTitle itemMainTitle="" itemSubTitle="사용자 랭킹" itemToggle={true} />
           <UserRank UserRankName="박시연의 도서관" UserRankGrade="1위" />
         </div>
       </div>
       <div className="flex">
         <div className="w-4/5">
-          <ItemTitle itemMainTitle="최신 매물" itemSubTitle="" />
+          <ItemTitle itemMainTitle="최신 매물" itemSubTitle="" itemToggle={true} />
           <ItemList itemName="원씽 The One Thing" itemPrice="500" itemState="대여가능" />
         </div>
         <div className="w-1/5">
-          <ItemTitle itemMainTitle="" itemSubTitle="인기 대여 책" />
+          <ItemTitle itemMainTitle="" itemSubTitle="인기 대여 책" itemToggle={true} />
           <UserRank UserRankName="구멍가게 이야기" UserRankGrade="박시연의 도서관" />
         </div>
       </div>


### PR DESCRIPTION
[MODO-41]

### 🔨 지라 이슈

-MODO-41-[HOTFIX]/mainPage: 
- Vercel 의 preview에서 Build 에러가 발생하는 문제를 해결했습니다.

### 📝 설명

- mainPage에서 쓰이는 ItemTitle 컴포넌트의 props인 itemToggle의 값을 선언하고, 지정해주지 않아서 발생했습니다.


[MODO-41]: https://ajoumodo.atlassian.net/browse/MODO-41?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ